### PR TITLE
Sanitize file names when extracting attachments

### DIFF
--- a/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
@@ -96,7 +96,6 @@ namespace Frends.Kungsbacka.Pdf.Tests
             string UnsafeFilename = "my:unsafe/file*name?|.txt";
             string SafeFilename = "my_unsafe_file_name__.txt";
 
-            // Arrange: generate PDF with unsafe attachment using TestHelper
             byte[] pdfWithUnsafe = TestHelper.CreatePdfWithAttachment(UnsafeFilename);
             var input = new PdfDocumentInput { PdfDocument = pdfWithUnsafe };
             var options = new ExtractAttachmentsOptions
@@ -123,7 +122,6 @@ namespace Frends.Kungsbacka.Pdf.Tests
         {
             string UnsafeFilename = "my safe file name.txt";
 
-            // Arrange: generate PDF with unsafe attachment using TestHelper
             byte[] pdfWithUnsafe = TestHelper.CreatePdfWithAttachment(UnsafeFilename);
             var input = new PdfDocumentInput { PdfDocument = pdfWithUnsafe };
             var options = new ExtractAttachmentsOptions

--- a/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
@@ -82,12 +82,67 @@ namespace Frends.Kungsbacka.Pdf.Tests
             {
                 PdfDocument = TestHelper.GetTestDocument(TestHelper.TestDocumentTypes.WithAttachments)
             };
-            var options = new PdfCommonOptions()
+            var options = new ExtractAttachmentsOptions()
             {
                 Filter = "*"
             };
             var result = PdfTasks.ExtractAttachments(input, options);
             Assert.AreEqual(6, result.Attachments.Count());
+        }
+
+        [Test]
+        public void ExtractAttachments_MakeFilenameSafe_True_ReplacesUnsafeChars()
+        {
+            string UnsafeFilename = "my:unsafe/file*name?|.txt";
+            string SafeFilename = "my_unsafe_file_name__.txt";
+
+            // Arrange: generate PDF with unsafe attachment using TestHelper
+            byte[] pdfWithUnsafe = TestHelper.CreatePdfWithAttachment(UnsafeFilename);
+            var input = new PdfDocumentInput { PdfDocument = pdfWithUnsafe };
+            var options = new ExtractAttachmentsOptions
+            {
+                MakeFilenameSafe = true,
+                ExtractOepPrefix = false,
+                Filter = "*"
+            };
+
+            // Act
+            var result = PdfTasks.ExtractAttachments(input, options);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Attachments);
+            Assert.IsNotEmpty(result.Attachments);
+            var attachment = result.Attachments.FirstOrDefault();
+            Assert.NotNull(attachment);
+            Assert.AreEqual(SafeFilename, attachment.Name);
+        }
+
+        [Test]
+        public void ExtractAttachments_MakeFilenameSafe_False_And_Filename_Is_actually_Safe_KeepsOriginalName()
+        {
+            string UnsafeFilename = "my safe file name.txt";
+
+            // Arrange: generate PDF with unsafe attachment using TestHelper
+            byte[] pdfWithUnsafe = TestHelper.CreatePdfWithAttachment(UnsafeFilename);
+            var input = new PdfDocumentInput { PdfDocument = pdfWithUnsafe };
+            var options = new ExtractAttachmentsOptions
+            {
+                MakeFilenameSafe = false,
+                ExtractOepPrefix = false,
+                Filter = "*"
+            };
+
+            // Act
+            var result = PdfTasks.ExtractAttachments(input, options);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.Attachments);
+            Assert.IsNotEmpty(result.Attachments);
+            var attachment = result.Attachments.FirstOrDefault();
+            Assert.NotNull(attachment);
+            Assert.AreEqual(UnsafeFilename, attachment.Name);
         }
 
         /// <summary>

--- a/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
@@ -93,6 +93,7 @@ namespace Frends.Kungsbacka.Pdf.Tests
         [Test]
         public void ExtractAttachments_MakeFilenameSafe_True_ReplacesUnsafeChars()
         {
+            //Arrange
             string UnsafeFilename = "my:unsafe/file*name?|.txt";
             string SafeFilename = "my_unsafe_file_name__.txt";
 
@@ -120,6 +121,7 @@ namespace Frends.Kungsbacka.Pdf.Tests
         [Test]
         public void ExtractAttachments_MakeFilenameSafe_False_And_Filename_Is_actually_Safe_KeepsOriginalName()
         {
+            //Arrange
             string UnsafeFilename = "my safe file name.txt";
 
             byte[] pdfWithUnsafe = TestHelper.CreatePdfWithAttachment(UnsafeFilename);

--- a/Frends.Kungsbacka.Pdf.Tests/TestHelper.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/TestHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using iText.IO.Source;
 using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Filespec;
 using NUnit.Framework;
 
 namespace Frends.Kungsbacka.Pdf.Tests
@@ -22,7 +23,7 @@ namespace Frends.Kungsbacka.Pdf.Tests
                 case TestDocumentTypes.WithAttachments:
                     fileName = "test-file-with-attachments.pdf";
                     break;
-				case TestDocumentTypes.ExtractText:
+                case TestDocumentTypes.ExtractText:
 					fileName = "Loremipsum.pdf";
 					break;
 				default:
@@ -30,6 +31,31 @@ namespace Frends.Kungsbacka.Pdf.Tests
             }
             return File.ReadAllBytes(Path.Combine(TestContext.CurrentContext.TestDirectory, "doc", fileName));
 
+        }
+
+        /// <summary>
+        /// Creates an in-memory PDF with a single file attachment named fileName.
+        /// </summary>
+        public static byte[] CreatePdfWithAttachment(string fileName)
+        {
+            using (var ms = new MemoryStream())
+            using (var writer = new PdfWriter(ms))
+            using (var pdfDoc = new PdfDocument(writer))
+            {
+                var fileBytes = new byte[] { 1, 2, 3 };
+                PdfFileSpec fs = PdfFileSpec.CreateEmbeddedFileSpec(
+                    pdfDoc,
+                    fileBytes,
+                    fileName,               // file specification name
+                    fileName,               // display file name
+                    null,                   // MIME type (none)
+                    new PdfDictionary(),    // params (empty)
+                    PdfName.Data            // AFRelationship
+                );
+                pdfDoc.AddFileAttachment(fileName, fs);
+                pdfDoc.Close();
+                return ms.ToArray();
+            }
         }
 
         public static void SaveResult(string fileName, byte[] pdfDocument)

--- a/Frends.Kungsbacka.Pdf/Definition.cs
+++ b/Frends.Kungsbacka.Pdf/Definition.cs
@@ -27,12 +27,26 @@ namespace Frends.Kungsbacka.Pdf
         /// </summary>
         [DisplayFormat(DataFormatString = "Text")]
         public string Filter { get; set; }
+
         /// <summary>
         /// Extract prefix from PDF description
         /// </summary>
         [DisplayFormat(DataFormatString = "Text")]
         public bool ExtractOepPrefix { get; set; }
     }
+
+    /// <summary>
+    /// Optional parameters for task ExtractAttachments
+    /// </summary>
+    public class ExtractAttachmentsOptions : PdfCommonOptions
+    {
+        /// <summary>
+        /// Replace system disallowed characters with '_' in resulting file name.
+        /// </summary>
+        [DefaultValueAttribute(true)]
+        public bool MakeFilenameSafe { get; set; } = true;
+    }
+
     public class WkHtmlMarginOptions
     {
         /// <summary>
@@ -56,6 +70,7 @@ namespace Frends.Kungsbacka.Pdf
 		[DefaultValue(10)]
         public int MarginRight { get; set; } = 10;
     }
+
     public class WkHtmlFooterOptions
     {
         /// <summary>
@@ -63,11 +78,13 @@ namespace Frends.Kungsbacka.Pdf
 		/// </summary>
 		[DefaultValue(0)]
         public int FooterSpacing { get; set; } = 0;
+
         /// <summary>
 		/// Include line above footer. Default is false
 		/// </summary>
         [DefaultValue(false)]
         public bool IncludeFooterLine { get; set; } = false;
+
         /// <summary>
 		/// URL to footer-file
 		/// </summary>

--- a/Frends.Kungsbacka.Pdf/Frends.Kungsbacka.Pdf.cs
+++ b/Frends.Kungsbacka.Pdf/Frends.Kungsbacka.Pdf.cs
@@ -146,7 +146,7 @@ namespace Frends.Kungsbacka.Pdf
         /// <param name="input">Mandatory parameters</param>
         /// <param name="options">Optional parameters</param>
         /// <returns>AttachmentResult {IEnumerable&lt;PdfAttachment&gt; Attachments}</returns>
-        public static ExtractAttachmentsResult ExtractAttachments([PropertyTab] PdfDocumentInput input, [PropertyTab] PdfCommonOptions options)
+        public static ExtractAttachmentsResult ExtractAttachments([PropertyTab] PdfDocumentInput input, [PropertyTab] ExtractAttachmentsOptions options)
         {
             if (input is null)
             {
@@ -156,11 +156,12 @@ namespace Frends.Kungsbacka.Pdf
             {
                 throw new ArgumentNullException(nameof(input.PdfDocument));
             }
+
             string pattern = options?.Filter ?? "*";
             var pdf = new Pdf(input.PdfDocument);
             var output = new ExtractAttachmentsResult
             {
-                Attachments = PdfTools.ExtractAttachments(pdf.Document, pattern, options.ExtractOepPrefix)
+                Attachments = PdfTools.ExtractAttachments(pdf.Document, pattern, options.ExtractOepPrefix, options.MakeFilenameSafe)
             };
             return output;
         }

--- a/Frends.Kungsbacka.Pdf/PdfTools.cs
+++ b/Frends.Kungsbacka.Pdf/PdfTools.cs
@@ -9,10 +9,8 @@ using iText.Kernel.Utils;
 using iText.Layout;
 using iText.Layout.Element;
 using iText.Layout.Properties;
-using iText.StyledXmlParser.Jsoup.Safety;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 

--- a/Frends.Kungsbacka.Pdf/PdfTools.cs
+++ b/Frends.Kungsbacka.Pdf/PdfTools.cs
@@ -110,7 +110,7 @@ namespace Frends.Kungsbacka.Pdf
         /// <param name="pdfDocument">Pdf document to extract from</param>
         /// <param name="pattern">Optional filter for file names</param>
         /// <param name="extractOepPrefix">Optional boolean for extracting oep prefixes from the description</param>
-        /// <param name="makeFilenameSafe">Optional boolean for removing system disallowed file name characters</param>
+        /// <param name="makeFilenameSafe">Optional boolean for replacing system disallowed file name characters with '_'</param>
         public static IEnumerable<PdfAttachment> ExtractAttachments(PdfDocument pdfDocument, string pattern = "", bool extractOepPrefix = false, bool makeFilenameSafe = true)
         {
             PdfArray fileSpecArray = GetFileSpecArray(pdfDocument);

--- a/Frends.Kungsbacka.Pdf/PdfTools.cs
+++ b/Frends.Kungsbacka.Pdf/PdfTools.cs
@@ -137,11 +137,11 @@ namespace Frends.Kungsbacka.Pdf
                 regex = GetRegexFromPattern(pattern);
             }
 
-            var list = new List<PdfAttachment>();
+            var attachments = new List<PdfAttachment>();
             int size = fileSpecArray.Size();
             if (size % 2 != 0)
             {
-                return list.AsEnumerable();
+                return attachments.AsEnumerable();
             }
 
             for (int i = 0; i < size; i += 2)
@@ -156,11 +156,11 @@ namespace Frends.Kungsbacka.Pdf
 
                     string oepPrefix = extractOepPrefix ? GetOepFilePrefix(fileSpec, fileName) : string.Empty;
 
-					if (!list.Any(x => x.Data.Length == stream.GetBytes().Length && x.Name == fileName))
+					if (!attachments.Any(x => x.Data.Length == stream.GetBytes().Length && x.Name == fileName))
 					{
                         if (regex == null || regex.IsMatch(fileName))
                         {
-                            list.Add(new PdfAttachment()
+                            attachments.Add(new PdfAttachment()
                             {
                                 Name = fileName,
                                 Extension = System.IO.Path.GetExtension(fileName), //Seems to actually allow many chars but exception on some though (ex. '|')
@@ -172,7 +172,7 @@ namespace Frends.Kungsbacka.Pdf
                 }
             }
 
-            return list.AsEnumerable();
+            return attachments.AsEnumerable();
         }
 
 
@@ -388,8 +388,8 @@ namespace Frends.Kungsbacka.Pdf
         /// by replacing invalid file name characters with underscores.
         /// </summary>
         /// <param name="dict">PdfDictionary representing a file specification to get the names from</param>
-        /// <param name="sanitizeFileNames">Optionally replace invalid chars with '_'</param>
-        private static string GetFileName(PdfDictionary dict, bool sanitizeFileNames = false)
+        /// <param name="sanitizeFileName">Optionally replace invalid chars with '_'</param>
+        private static string GetFileName(PdfDictionary dict, bool sanitizeFileName = false)
         {
             if (dict == null)
             {
@@ -403,7 +403,7 @@ namespace Frends.Kungsbacka.Pdf
             
             string fileName = dict.GetAsString(PdfName.F).ToString();
 
-            if (sanitizeFileNames)
+            if (sanitizeFileName)
             {
                 char[] invalidFileChars = System.IO.Path.GetInvalidFileNameChars();
                 fileName = new string(fileName.Select(ch => invalidFileChars.Any(invCh => invCh == ch) ? '_' : ch).ToArray());

--- a/Frends.Kungsbacka.Pdf/PdfTools.cs
+++ b/Frends.Kungsbacka.Pdf/PdfTools.cs
@@ -152,7 +152,7 @@ namespace Frends.Kungsbacka.Pdf
                 {
                     PdfDictionary refs = fileSpec.GetAsDictionary(PdfName.EF);  
                     PdfStream stream = GetStream(refs);
-                    string fileName = GetFileName(fileSpec);
+                    string fileName = GetFileName(fileSpec, makeFilenameSafe);
 
                     string oepPrefix = extractOepPrefix ? GetOepFilePrefix(fileSpec, fileName) : string.Empty;
 
@@ -396,12 +396,16 @@ namespace Frends.Kungsbacka.Pdf
                 return null;
             }
 
+            string fileName = string.Empty;
+
             if (dict.ContainsKey(PdfName.UF))
             {
-                return dict.GetAsString(PdfName.UF).ToString();
+                fileName = dict.GetAsString(PdfName.UF).ToString();
             }
-            
-            string fileName = dict.GetAsString(PdfName.F).ToString();
+            else
+            {
+                fileName = dict.GetAsString(PdfName.F).ToString();
+            }
 
             if (sanitizeFileName)
             {


### PR DESCRIPTION
ExtractAttachments task now has the option to sanitize file names to replace illegal chars with '_'. (Just removing them resulted in unreadable file names).

Also adds unit tests targeting the new functionality.