### PR TITLE
10033 suffix extract attachments

### DIFF
--- a/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
@@ -61,8 +61,6 @@ namespace Frends.Kungsbacka.Pdf.Tests
 
             var result = PdfTasks.ExtractAttachments(input, options);
 
-            Assert.AreEqual(2, result.Attachments.Count());
-
             var names = result.Attachments.Select(a => a.Name).ToList();
 
             // Default behavior: allow duplicate display names (two returned attachments should both be "doc.pdf")

--- a/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
@@ -53,7 +53,7 @@ namespace Frends.Kungsbacka.Pdf.Tests
         [Test]
         public void ExtractAttachments_DoesNotAppend_WhenNotRequested()
         {
-            var fileNames = new[] { "doc.pdf", "doc.pdf" };
+            var fileNames = new[] { "doc.pdf", "doc1.pdf" };
             var pdfBytes = TestHelper.CreatePdfWithAttachment(fileNames);
 
             var input = new PdfDocumentInput { PdfDocument = pdfBytes };
@@ -64,14 +64,14 @@ namespace Frends.Kungsbacka.Pdf.Tests
             var names = result.Attachments.Select(a => a.Name).ToList();
 
             // Default behavior: allow duplicate display names (two returned attachments should both be "doc.pdf")
-            var expected = new[] { "doc.pdf", "doc.pdf" };
+            var expected = new[] { "doc.pdf", "doc1.pdf" };
             CollectionAssert.AreEqual(expected, names);
         }
 
         [Test]
         public void ExtractAttachments_DoesNotAppend_WhenAppendAttachmentNumberNotSet()
         {
-            var fileNames = new[] { "doc.pdf", "doc.pdf" };
+            var fileNames = new[] { "doc.pdf", "doc1.pdf" };
             var pdfBytes = TestHelper.CreatePdfWithAttachment(fileNames);
 
             var input = new PdfDocumentInput { PdfDocument = pdfBytes };
@@ -82,7 +82,25 @@ namespace Frends.Kungsbacka.Pdf.Tests
             var names = result.Attachments.Select(a => a.Name).ToList();
 
             // Default behavior: allow duplicate display names
-            var expected = new[] { "doc.pdf", "doc.pdf" };
+            var expected = new[] { "doc.pdf", "doc1.pdf" };
+            CollectionAssert.AreEqual(expected, names);
+        }
+
+        [Test]
+        public void ExtractAttachments_RemovesDuplicates_WhenFilesAreSameLengthAndHaveSameName()
+        {
+            var fileNames = new[] { "doc.pdf", "doc.pdf" };
+            var pdfBytes = TestHelper.CreatePdfWithAttachment(fileNames);
+
+            var input = new PdfDocumentInput { PdfDocument = pdfBytes };
+            var options = new ExtractAttachmentsOptions { Filter = "*", MakeFilenameSafe = true };
+
+            var result = PdfTasks.ExtractAttachments(input, options);
+
+            var names = result.Attachments.Select(a => a.Name).ToList();
+
+            // Default behavior: allow duplicate display names
+            var expected = new[] { "doc.pdf" };
             CollectionAssert.AreEqual(expected, names);
         }
 

--- a/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
@@ -99,7 +99,6 @@ namespace Frends.Kungsbacka.Pdf.Tests
 
             var names = result.Attachments.Select(a => a.Name).ToList();
 
-            // Default behavior: allow duplicate display names
             var expected = new[] { "doc.pdf" };
             CollectionAssert.AreEqual(expected, names);
         }

--- a/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/Frends.Kungsbacka.Pdf.Tests.cs
@@ -30,10 +30,68 @@ namespace Frends.Kungsbacka.Pdf.Tests
             TestHelper.SaveResult("convert-embedded-images-to-pages-test-result.pdf", result.PdfDocument);
 		}
 
-		/// <summary>
-		/// Test ConvertEmbeddedImagesToPagesShouldOnlyContainDocuments
-		/// </summary>
-		[Test]
+        [Test]
+        public void ExtractAttachments_AppendsNumber_WhenRequested()
+        {
+            var fileNames = new[] { "doc.pdf", "doc.pdf", "other.txt" };
+            var pdfBytes = TestHelper.CreatePdfWithAttachment(fileNames);
+
+            var input = new PdfDocumentInput { PdfDocument = pdfBytes };
+            var options = new ExtractAttachmentsOptions { Filter = "*", MakeFilenameSafe = true, AppendAttachmentNumber = true };
+
+            var result = PdfTasks.ExtractAttachments(input, options);
+
+            Assert.AreEqual(3, result.Attachments.Count());
+
+            var names = result.Attachments.Select(a => a.Name).ToList();
+
+            // Expect exact file names in order when appending numbers
+            var expected = new[] { "doc_bilaga1.pdf", "doc_bilaga2.pdf", "other_bilaga3.txt" };
+            CollectionAssert.AreEqual(expected, names);
+        }
+
+        [Test]
+        public void ExtractAttachments_DoesNotAppend_WhenNotRequested()
+        {
+            var fileNames = new[] { "doc.pdf", "doc.pdf" };
+            var pdfBytes = TestHelper.CreatePdfWithAttachment(fileNames);
+
+            var input = new PdfDocumentInput { PdfDocument = pdfBytes };
+            var options = new ExtractAttachmentsOptions { Filter = "*", MakeFilenameSafe = true, AppendAttachmentNumber = false };
+
+            var result = PdfTasks.ExtractAttachments(input, options);
+
+            Assert.AreEqual(2, result.Attachments.Count());
+
+            var names = result.Attachments.Select(a => a.Name).ToList();
+
+            // Default behavior: allow duplicate display names (two returned attachments should both be "doc.pdf")
+            var expected = new[] { "doc.pdf", "doc.pdf" };
+            CollectionAssert.AreEqual(expected, names);
+        }
+
+        [Test]
+        public void ExtractAttachments_DoesNotAppend_WhenAppendAttachmentNumberNotSet()
+        {
+            var fileNames = new[] { "doc.pdf", "doc.pdf" };
+            var pdfBytes = TestHelper.CreatePdfWithAttachment(fileNames);
+
+            var input = new PdfDocumentInput { PdfDocument = pdfBytes };
+            var options = new ExtractAttachmentsOptions { Filter = "*", MakeFilenameSafe = true};
+
+            var result = PdfTasks.ExtractAttachments(input, options);
+
+            var names = result.Attachments.Select(a => a.Name).ToList();
+
+            // Default behavior: allow duplicate display names
+            var expected = new[] { "doc.pdf", "doc.pdf" };
+            CollectionAssert.AreEqual(expected, names);
+        }
+
+        /// <summary>
+        /// Test ConvertEmbeddedImagesToPagesShouldOnlyContainDocuments
+        /// </summary>
+        [Test]
 		public void ConvertEmbeddedImagesToPagesShouldOnlyContainDocuments()
 		{
 			var input = new PdfDocumentInput

--- a/Frends.Kungsbacka.Pdf.Tests/TestHelper.cs
+++ b/Frends.Kungsbacka.Pdf.Tests/TestHelper.cs
@@ -30,29 +30,39 @@ namespace Frends.Kungsbacka.Pdf.Tests
                     throw new ArgumentException(nameof(testDocumentType));
             }
             return File.ReadAllBytes(Path.Combine(TestContext.CurrentContext.TestDirectory, "doc", fileName));
-
         }
 
         /// <summary>
-        /// Creates an in-memory PDF with a single file attachment named fileName.
+        /// Creates an in-memory PDF with one or many file attachments named fileName.
         /// </summary>
-        public static byte[] CreatePdfWithAttachment(string fileName)
+        public static byte[] CreatePdfWithAttachment(params string[] fileNames)
         {
             using (var ms = new MemoryStream())
             using (var writer = new PdfWriter(ms))
             using (var pdfDoc = new PdfDocument(writer))
             {
                 var fileBytes = new byte[] { 1, 2, 3 };
-                PdfFileSpec fs = PdfFileSpec.CreateEmbeddedFileSpec(
-                    pdfDoc,
-                    fileBytes,
-                    fileName,               // file specification name
-                    fileName,               // display file name
-                    null,                   // MIME type (none)
-                    new PdfDictionary(),    // params (empty)
-                    PdfName.Data            // AFRelationship
-                );
-                pdfDoc.AddFileAttachment(fileName, fs);
+                int idx = 0;
+                foreach (var fileName in fileNames)
+                {
+                    idx++;
+                    // Use a unique internal attachment key that preserves the
+                    // insertion order when stored in the PDF name tree. The PDF
+                    // name tree requires keys to be sorted; prefixing with a
+                    // zero-padded index ensures the lexical sort matches the
+                    // original order.
+                    var internalName = idx.ToString("D4") + "_" + fileName;
+                    PdfFileSpec fs = PdfFileSpec.CreateEmbeddedFileSpec(
+                        pdfDoc,
+                        fileBytes,
+                        internalName,           // file specification name (internal key)
+                        fileName,               // display file name
+                        null,                   // MIME type (none)
+                        new PdfDictionary(),    // params (empty)
+                        PdfName.Data            // AFRelationship
+                    );
+                    pdfDoc.AddFileAttachment(internalName, fs);
+                }
                 pdfDoc.Close();
                 return ms.ToArray();
             }

--- a/Frends.Kungsbacka.Pdf/Definition.cs
+++ b/Frends.Kungsbacka.Pdf/Definition.cs
@@ -57,6 +57,12 @@ namespace Frends.Kungsbacka.Pdf
         /// </summary>
         [DefaultValueAttribute(true)]
         public bool MakeFilenameSafe { get; set; } = true;
+
+        /// <summary>
+        /// Append an ordinal suffix "_bilagaN" before the extension to make file names unique.
+        /// </summary>
+        [DefaultValueAttribute(false)]
+        public bool AppendAttachmentNumber { get; set; } = false;
     }
 
     public class WkHtmlMarginOptions

--- a/Frends.Kungsbacka.Pdf/Frends.Kungsbacka.Pdf.cs
+++ b/Frends.Kungsbacka.Pdf/Frends.Kungsbacka.Pdf.cs
@@ -161,7 +161,7 @@ namespace Frends.Kungsbacka.Pdf
             var pdf = new Pdf(input.PdfDocument);
             var output = new ExtractAttachmentsResult
             {
-                Attachments = PdfTools.ExtractAttachments(pdf.Document, pattern, options.ExtractOepPrefix, options.MakeFilenameSafe)
+                Attachments = PdfTools.ExtractAttachments(pdf.Document, pattern, options.ExtractOepPrefix, options.MakeFilenameSafe, options.AppendAttachmentNumber)
             };
             return output;
         }

--- a/Frends.Kungsbacka.Pdf/Frends.Kungsbacka.Pdf.csproj
+++ b/Frends.Kungsbacka.Pdf/Frends.Kungsbacka.Pdf.csproj
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.5.10</Version>
+    <Version>1.6.0</Version>
 	<LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/Frends.Kungsbacka.Pdf/PdfTools.cs
+++ b/Frends.Kungsbacka.Pdf/PdfTools.cs
@@ -121,7 +121,8 @@ namespace Frends.Kungsbacka.Pdf
         /// <param name="pattern">Optional filter for file names</param>
         /// <param name="extractOepPrefix">Optional boolean for extracting oep prefixes from the description</param>
         /// <param name="makeFilenameSafe">Optional boolean for replacing system disallowed file name characters with '_'</param>
-        public static IEnumerable<PdfAttachment> ExtractAttachments(PdfDocument pdfDocument, string pattern = "", bool extractOepPrefix = false, bool makeFilenameSafe = true)
+        /// <param name="appendAttachmentNumber">Optional boolean for appending the attachment number to the file name to avoid duplicates</param>
+        public static IEnumerable<PdfAttachment> ExtractAttachments(PdfDocument pdfDocument, string pattern = "", bool extractOepPrefix = false, bool makeFilenameSafe = true, bool appendAttachmentNumber = false)
         {
             PdfArray fileSpecArray = GetFileSpecArray(pdfDocument);
 
@@ -138,6 +139,7 @@ namespace Frends.Kungsbacka.Pdf
             }
 
             var attachments = new List<PdfAttachment>();
+            int attachmentNumber = 0;
             int size = fileSpecArray.Size();
             if (size % 2 != 0)
             {
@@ -150,24 +152,30 @@ namespace Frends.Kungsbacka.Pdf
 
                 if (fileSpec != null)
                 {
-                    PdfDictionary refs = fileSpec.GetAsDictionary(PdfName.EF);  
+                    PdfDictionary refs = fileSpec.GetAsDictionary(PdfName.EF);
                     PdfStream stream = GetStream(refs);
-                    string fileName = GetFileName(fileSpec, makeFilenameSafe);
 
-                    string oepPrefix = extractOepPrefix ? GetOepFilePrefix(fileSpec, fileName) : string.Empty;
+                    if (stream == null)
+                        continue;
 
-					if (!attachments.Any(x => x.Data.Length == stream.GetBytes().Length && x.Name == fileName))
-					{
-                        if (regex == null || regex.IsMatch(fileName))
+                    string originalName = GetFileName(fileSpec, makeFilenameSafe);
+
+                    if (regex == null || regex.IsMatch(originalName))
+                    {
+                        attachmentNumber++;
+
+                        string oepPrefix = extractOepPrefix ? GetOepFilePrefix(fileSpec, originalName) : string.Empty;
+                        string ext = System.IO.Path.GetExtension(originalName);
+                        string nameOnly = System.IO.Path.GetFileNameWithoutExtension(originalName);
+                        string finalName = BuildAttachmentName(originalName, attachmentNumber, appendAttachmentNumber);
+
+                        attachments.Add(new PdfAttachment()
                         {
-                            attachments.Add(new PdfAttachment()
-                            {
-                                Name = fileName,
-                                Extension = System.IO.Path.GetExtension(fileName), //Seems to actually allow many chars but exception on some though (ex. '|')
-                                Data = stream.GetBytes(),
-                                OepPrefix = oepPrefix
-                            });
-                        }
+                            Name = finalName,
+                            Extension = ext,
+                            Data = stream.GetBytes(),
+                            OepPrefix = oepPrefix
+                        });
                     }
                 }
             }
@@ -194,6 +202,19 @@ namespace Frends.Kungsbacka.Pdf
             }
 
             return string.Empty;
+        }
+
+
+        private static string BuildAttachmentName(string originalName, int index, bool appendNumber)
+        {
+            if (!appendNumber) return originalName;
+
+            string ext = System.IO.Path.GetExtension(originalName);
+            string nameOnly = System.IO.Path.GetFileNameWithoutExtension(originalName);
+
+            return string.IsNullOrEmpty(ext)
+                ? $"{nameOnly}_bilaga{index}"
+                : $"{nameOnly}_bilaga{index}{ext}";
         }
 
 

--- a/Frends.Kungsbacka.Pdf/PdfTools.cs
+++ b/Frends.Kungsbacka.Pdf/PdfTools.cs
@@ -12,6 +12,7 @@ using iText.Layout.Properties;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 using System.Text.RegularExpressions;
 
 namespace Frends.Kungsbacka.Pdf
@@ -145,7 +146,7 @@ namespace Frends.Kungsbacka.Pdf
             {
                 return attachments.AsEnumerable();
             }
-
+            
             for (int i = 0; i < size; i += 2)
             {
                 PdfDictionary fileSpec = fileSpecArray.GetAsDictionary(i + 1);
@@ -154,11 +155,17 @@ namespace Frends.Kungsbacka.Pdf
                 {
                     PdfDictionary refs = fileSpec.GetAsDictionary(PdfName.EF);
                     PdfStream stream = GetStream(refs);
+                    string originalName = GetFileName(fileSpec, makeFilenameSafe);
 
                     if (stream == null)
+                    {
                         continue;
+                    }
 
-                    string originalName = GetFileName(fileSpec, makeFilenameSafe);
+                    if (attachments.Any(x => x.Data.Length == stream.GetBytes().Length && x.Name == originalName))
+                    {
+                        continue;
+                    }
 
                     if (regex == null || regex.IsMatch(originalName))
                     {

--- a/Frends.Kungsbacka.Pdf/PdfTools.cs
+++ b/Frends.Kungsbacka.Pdf/PdfTools.cs
@@ -167,11 +167,11 @@ namespace Frends.Kungsbacka.Pdf
                         string oepPrefix = extractOepPrefix ? GetOepFilePrefix(fileSpec, originalName) : string.Empty;
                         string ext = System.IO.Path.GetExtension(originalName);
                         string nameOnly = System.IO.Path.GetFileNameWithoutExtension(originalName);
-                        string finalName = BuildAttachmentName(originalName, attachmentNumber, appendAttachmentNumber);
+                        string fileName = BuildAttachmentName(originalName, attachmentNumber, appendAttachmentNumber);
 
                         attachments.Add(new PdfAttachment()
                         {
-                            Name = finalName,
+                            Name = fileName,
                             Extension = ext,
                             Data = stream.GetBytes(),
                             OepPrefix = oepPrefix


### PR DESCRIPTION
Vi stöter på problem då OpenE kan leverera flera bilagor med samma namn, den här ändringen ger oss möjligheten att suffixa alla bilagor med "_bilagaN" för att komma runt detta. Är false by default för att inte störa andra processer.

BUG: [Felsökning-Utläsning av bilagor med samma namn i OpenE](https://dev.azure.com/Kungsbacka/DC%20Utveckling/_workitems/edit/10033)